### PR TITLE
Add schedule show event create index#25

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -96,3 +96,7 @@ Style/BlockComments:
 # 定数に冗長な 「::」プレフィックスがないか指摘
 Style/RedundantConstantBase:
   Enabled: false
+
+# 進数を明示的に指定しているか
+Style/NumericLiteralPrefix:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -83,7 +83,7 @@ RSpec/ContextWording:
 
 # specのコードの長さを指摘
 RSpec/ExampleLength:
-  Max: 10
+  Max: 20
 
 # expectの数を指摘
 RSpec/MultipleExpectations:

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,0 +1,25 @@
+class EventsController < ApplicationController
+  before_action :set_schedule, only: %i[new create]
+  def new
+    @event = @schedule.events.build
+  end
+
+  def create
+    @event = @schedule.events.new(event_params)
+    if @event.save
+      @events = @schedule.events.start_time_order
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def event_params
+    params.require(:event).permit(:start_time, :end_time, :event_title, :image, :price, :comment)
+  end
+
+  def set_schedule
+    @schedule = Schedule.find(params[:schedule_id])
+  end
+end

--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -1,7 +1,12 @@
 class SchedulesController < ApplicationController
   skip_before_action :require_login, only: %i[index]
+  before_action :set_schedule, only: %i[show]
   def index
     @schedules = Schedule.preload(%i[user])
+  end
+
+  def show
+    @events = @schedule.events.start_time_order
   end
 
   def new
@@ -22,5 +27,9 @@ class SchedulesController < ApplicationController
 
   def schedule_params
     params.require(:schedule).permit(:schedule_title, :assumed_number_people, :get_up_time, :sleep_time)
+  end
+
+  def set_schedule
+    @schedule = Schedule.find(params[:id])
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,0 +1,12 @@
+class Event < ApplicationRecord
+  belongs_to :schedule
+
+  validates :start_time, presence: true
+  validates :event_title, presence: true, length: { maximum: 18 }
+
+  has_one_attached :image do |attachable|
+    attachable.variant :user_index, resize_to_limit: [100, 100]
+  end
+
+  scope :start_time_order, -> { order(start_time: :ASC) }
+end

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -1,5 +1,7 @@
 class Schedule < ApplicationRecord
   belongs_to :user
+  has_many :events, dependent: :destroy
+
   validates :schedule_title, presence: true, length: { maximum: 13 }
   validates :assumed_number_people, presence: true
   validates :get_up_time, presence: true

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -8,4 +8,12 @@ class Schedule < ApplicationRecord
   validates :sleep_time, presence: true
 
   enum assumed_number_people: { one_person: 0, two_people: 1, three_people: 2, four_or_more_people: 3 }
+
+  def total_price
+    total_price = 0
+    events.each do |event|
+      total_price += event.price if event.price
+    end
+    total_price
+  end
 end

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -1,4 +1,6 @@
 class Schedule < ApplicationRecord
+  before_save :check_day_sleep_time
+  
   belongs_to :user
   has_many :events, dependent: :destroy
 
@@ -15,5 +17,9 @@ class Schedule < ApplicationRecord
       total_price += event.price if event.price
     end
     total_price
+  end
+
+  def check_day_sleep_time
+    sleep_time + 1.day if get_up_time > sleep_time
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,10 +1,14 @@
 class User < ApplicationRecord
-  before_create :default_avatar
+  before_save :default_avatar
+
   authenticates_with_sorcery!
+
   has_one_attached :avatar do |attachable|
     attachable.variant :user_index, resize_to_limit: [100, 100]
   end
+
   has_many :schedules, dependent: :destroy
+
   validates :password, length: { minimum: 3 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,7 @@ class User < ApplicationRecord
 
   has_one_attached :avatar do |attachable|
     attachable.variant :user_index, resize_to_limit: [100, 100]
+    attachable.variant :user_show, resize_to_limit: [160, 160]
   end
 
   has_many :schedules, dependent: :destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,6 +16,15 @@ class User < ApplicationRecord
   validates :email, uniqueness: true, presence: true
   validates :name, presence: true, length: { maximum: 255 }
   validates :avatar, content_type: ['image/png', 'image/jpg', 'image/jpeg']
+
+  def own?(object)
+    id == object.user_id
+  end
+
+  def mine?(object)
+    id == object.id
+  end
+
   private
 
   def default_avatar

--- a/app/views/events/_event.html.erb
+++ b/app/views/events/_event.html.erb
@@ -1,0 +1,13 @@
+<%= link_to '#' do %>
+    <div class="flex w-4/5 sm:w-2/3 bg-secondary rounded-lg drop-shadow-xl text-white mx-auto p-2 mt-4 text-center hover:duration-300 hover:scale-105">
+        <div class="flex">
+            <h2><%= l event.start_time %></h2>
+            <% if event.end_time %>
+              <h2>~ <%= l event.end_time %></h2>
+            <% end %>
+        </div>
+        <div class="m-auto">
+            <h2><%= event.event_title %></h2>
+        </div>
+    </div>
+<% end %>

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -1,0 +1,49 @@
+<%= form_with model: [schedule, event] do |f| %>
+    <%= render 'shared/error_messages', object: f.object %>
+    <div class="bg-secondary-content drop-shadow-xl rounded-lg m-2 p-5 grid grid-cols-1 sm:grid-cols-2 gap-2">
+
+        <div class="form-control">
+            <label class="input-group input-group-sm input-group-vertical">
+                <span class="text-sm"><%= Event.human_attribute_name(:start_time) %></span>
+                <%= f.time_field :start_time, min: schedule.get_up_time, max: schedule.sleep_time, class: 'input input-bordered input-sm' %>
+            </label>
+        </div>
+
+        <div class="form-control">
+            <label class="input-group input-group-sm input-group-vertical">
+                <span class="text-sm"><%= Event.human_attribute_name(:end_time) %></span>
+                <%= f.time_field :end_time, min: schedule.get_up_time, max: schedule.sleep_time, class: 'input input-bordered input-sm' %>
+            </label>
+        </div>
+
+        <div class="form-control sm:col-span-2">
+            <label class="input-group input-group-sm input-group-vertical">
+                <span class="text-sm"><%= Event.human_attribute_name(:event_title) %></span>
+                <%= f.text_field :event_title, placeholder: true, class: 'input input-bordered input-sm' %>
+            </label>
+        </div>
+
+        <div>
+            <%= f.file_field :image, class: 'file-input file-input-bordered file-input-md w-full file:text-sm file:text-white file:bg-secondary' %>
+        </div>
+
+        <div class="form-control">
+            <label class="input-group input-group-sm input-group-vertical">
+                <span class="text-sm"><%= Event.human_attribute_name(:price) %></span>
+                <%= f.number_field :price, placeholder: true, class: 'input input-bordered input-sm' %>
+            </label>
+        </div>
+
+        <div class="form-control sm:col-span-2">
+            <label class="input-group input-group-sm input-group-vertical">
+                <span class="text-sm"><%= Event.human_attribute_name(:comment) %></span>
+                <%= f.text_area :comment, placeholder: true, class: 'textarea' %>
+            </label>
+        </div>
+
+        <div class="flex justify-end sm:col-span-2">
+            <%= link_to t('defaults.cansel'), schedule_path(@event.schedule), class: 'btn text-white', data: { turbo_frame: dom_id(@event, :show) } %>
+            <%= f.submit class: 'btn btn-primary text-white' %>
+        </div>
+    </div>
+<% end %>

--- a/app/views/events/create.turbo_stream.erb
+++ b/app/views/events/create.turbo_stream.erb
@@ -1,0 +1,7 @@
+<%= turbo_stream.update dom_id(Event.new), "" %>
+
+<%= turbo_stream.update dom_id(@schedule, :events) do%>
+  <% @events.each do |event| %>
+    <%= render 'event', schedule: @schedule, event: event %>
+  <% end %>
+<% end %>

--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -1,0 +1,3 @@
+<%= turbo_frame_tag dom_id(Event.new) do %>
+    <%= render 'form', schedule: @schedule, event: @event %>
+<% end %>

--- a/app/views/schedules/_schedule.html.erb
+++ b/app/views/schedules/_schedule.html.erb
@@ -1,5 +1,5 @@
 <div class='container relative p-2 bg-white drop-shadow-xl hover:border-4'>
-    <%= link_to "#", class: 'absolute top-0 left-0 right-0 bottom-0' do %>
+    <%= link_to schedule_path(schedule), class: 'absolute top-0 left-0 right-0 bottom-0' do %>
     <% end %>
 
     <div class='flex'>

--- a/app/views/schedules/show.html.erb
+++ b/app/views/schedules/show.html.erb
@@ -1,0 +1,55 @@
+<div class="bg-primary-content min-h-screen">
+    <div class="container mx-auto p-4">
+        <div class="flex p-4">
+            <%= link_to '#' do %>
+                <div class="avatar">
+                  <div class="w-16 md:w-20 rounded-full border-2 border-primary shadow-xl ">
+                    <%= image_tag @schedule.user.avatar.variant(:user_show) %>
+                  </div>
+                  <h2 class="pt-6 pl-8"><span class="text-xl md:text-3xl"><%= @schedule.user.name %></span></h2>
+                </div>
+            <% end %>
+        </div>
+
+        <div class="pl-4 pb-4">
+            <h1 class="text-2xl md:text-5xl font-serif"><%= @schedule.schedule_title %></h1>
+        </div>
+
+        <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
+            <div class="flex">
+                <h2><span class="text-lg md:text-xl"><%= t('defaults.people') %></span></h2>
+                <h2><span class="text-lg md:text-xl"><%= @schedule.assumed_number_people_i18n %></span></h2>
+            </div>
+            <div class="flex">
+                <h2><span class="text-lg md:text-xl"><%= t('defaults.money') %></span></h2>
+                <h2><span class="text-lg md:text-xl"><%= @schedule.total_price %></span>円</h2>
+            </div>
+            <div class="flex">
+                <h2><span class="text-lg md:text-xl"><%= t('defaults.get_up') %></span></h2>
+                <h2><span class="text-lg md:text-xl"><%= l @schedule.get_up_time %></span></h2>
+            </div>
+            <div class="flex">
+                <h2><span class="text-lg md:text-xl"><%= t('defaults.sleep') %></span></h2>
+                <h2><span class="text-lg md:text-xl"><%= l @schedule.sleep_time %></span></h2>
+            </div>
+        </div>
+
+        <% if current_user&.own?(@schedule) %>
+            <div class="flex flex-wrap justify-center gap-4 mt-16 ">
+                <%= link_to t('.create_event'), new_schedule_event_path(schedule_id: @schedule.id), class: 'btn btn-wide btn-secondary drop-shadow-xl text-white', data: { turbo_frame: dom_id(Event.new) } %>
+            </div>
+        <% end %>
+
+        <%= turbo_frame_tag dom_id(Event.new) %>
+
+        <div class="divider my-8"><%= t('defaults.get_up') %>  <%= l @schedule.get_up_time %></div>
+
+        <%= turbo_frame_tag dom_id(@schedule, :events) do %>
+          <% @events.each do |event| %>
+            <%= render 'events/event', schedule: @schedule, event: %>
+          <% end %>
+        <% end %>
+
+        <div class="divider mt-8"><%= t('defaults.sleep') %>  <%= l @schedule.sleep_time %></div>
+    </div>
+</div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -37,7 +37,7 @@ module Webapp
     config.i18n.default_locale = :ja
     config.i18n.load_path += Dir[Rails.root.join('config/locales/**/*.{rb,yml}').to_s]
 
-    config.time_zone = 'Tokyo'
+    config.time_zone = 'Asia/Tokyo'
 
     config.generators do |g|
       g.helper false

--- a/config/locales/helpers/ja.yml
+++ b/config/locales/helpers/ja.yml
@@ -9,3 +9,8 @@ ja:
       update: '更新'
     select:
       prompt: '選択してください'
+    placeholder:
+      event:
+        event_title: '〜をする'
+        price: '000円'
+        comment: '〜がおすすめです'

--- a/config/locales/models/ja.yml
+++ b/config/locales/models/ja.yml
@@ -17,6 +17,14 @@ ja:
         assumed_number_people: '人数'
         get_up_time: '起床時間'
         sleep_time: '就寝時間'
+      event:
+        id: 'ID'
+        start_time: '開始時間（必須）'
+        end_time: '終了時間'
+        event_title: 'タイトル（必須）'
+        image: '画像'
+        price: '価格'
+        comment: 'コメント'
   enums:
     schedule:
       assumed_number_people: 

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -1,5 +1,6 @@
 ja:
   defaults:
+    cansel: 'キャンセル'
     login: 'ログイン'
     signup: 'ユーザー登録'
     logout: 'ログアウト'
@@ -13,6 +14,7 @@ ja:
     people: '人数'
     get_up: '起床'
     sleep: '就寝'
+    money: '金額'
     message:
       require_login: 'ログインしてください'
   time:
@@ -38,3 +40,5 @@ ja:
     create:
       success: "スケジュール「%{title}」を作成しました"
       fail: 'スケジュールの作成に失敗しました'
+    show:
+      create_event: 'イベント作成'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,8 @@ Rails.application.routes.draw do
   post 'login', to: 'user_sessions#create'
   delete 'logout', to: 'user_sessions#destroy'
   resources :users, only: %i[new create]
-  resources :schedules, only: %i[new create index]
+  resources :schedules do
+    resources :events
+  end
   root to: 'static_pages#top'
 end

--- a/db/migrate/20230612064959_create_events.rb
+++ b/db/migrate/20230612064959_create_events.rb
@@ -1,0 +1,14 @@
+class CreateEvents < ActiveRecord::Migration[7.0]
+  def change
+    create_table :events do |t|
+      t.string :event_title, null: false
+      t.time :start_time,    null: false
+      t.time :end_time
+      t.integer :price
+      t.string :comment
+      t.references :schedule, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_11_081240) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_12_064959) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -42,6 +42,18 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_11_081240) do
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
+  create_table "events", force: :cascade do |t|
+    t.string "event_title", null: false
+    t.time "start_time", null: false
+    t.time "end_time"
+    t.integer "price"
+    t.string "comment"
+    t.bigint "schedule_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["schedule_id"], name: "index_events_on_schedule_id"
+  end
+
   create_table "schedules", force: :cascade do |t|
     t.string "schedule_title", null: false
     t.integer "assumed_number_people", null: false
@@ -65,5 +77,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_11_081240) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "events", "schedules"
   add_foreign_key "schedules", "users"
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,8 @@ services:
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: password
-      SELENIUM_REMOTE_URL: http://chrome:4444/wd/hub
+      SELENIUM_DRIVER_URL: http://chrome:4444/wd/hub
+      TZ: Asia/Tokyo
     volumes:
       - .:/webapp
     ports:
@@ -26,7 +27,9 @@ services:
       - db
       - chrome
   chrome:
-    image: selenium/standalone-chrome:latest
+    image: selenium/standalone-chrome-debug
+    logging:
+      driver: none
     ports:
       - 4444:4444
     shm_size: 2gb

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :event do
+    event_title { "title" }
+    start_time { "2000-01-01 07:50:00" }
+    end_time { "2000-01-01 08:50:00" }
+    price { 500 }
+    comment { "comment" }
+    schedule
+  end
+end

--- a/spec/factories/schedules.rb
+++ b/spec/factories/schedules.rb
@@ -2,8 +2,8 @@ FactoryBot.define do
   factory :schedule do
     schedule_title { "スケジュール" }
     assumed_number_people { 1 }
-    get_up_time { "1970-01-01 05:22:24" }
-    sleep_time { "1970-01-01 05:22:24" }
+    get_up_time { "2000-01-01 07:00:00" }
+    sleep_time { "2000-01-01 21:00:00" }
     user
   end
 end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -21,8 +21,9 @@ RSpec.configure do |config|
       driven_by :selenium, using: :chrome, options: {
         browser: :remote,
         url: ENV.fetch("SELENIUM_DRIVER_URL"),
-        desired_capabilities: :chrome
+        options: :chrome
       }
+      Capybara.server_host = IPSocket.getaddress(Socket.gethostname)
     else
       driven_by :selenium_chrome_headless
     end

--- a/spec/system/event_spec.rb
+++ b/spec/system/event_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe 'Schedules' do
+  let(:user) { create(:user) }
+  let(:schedule) { create(:schedule, user:) }
+
+  describe 'Event CRUD' do
+    describe 'イベント新規作成' do
+      it 'イベント新規作成ができる', js: true do
+        login_as(user)
+        visit schedule_path(schedule)
+        click_on 'イベント作成'
+        fill_in '開始時間（必須）', with: Time.zone.local(2000, 1, 1, 12, 00, 00)
+        fill_in '終了時間', with: Time.zone.local(2000, 1, 1, 12, 00, 00)
+        fill_in 'タイトル（必須）', with: 'イベント投稿テスト'
+        fill_in '価格', with: '500'
+        fill_in 'コメント', with: 'コメントのテストをしています'
+        click_button '作成'
+        expect(page).to have_content 'イベント投稿テスト'
+        expect(page).to have_current_path schedule_path(schedule), ignore_query: true
+      end
+    end
+  end
+end


### PR DESCRIPTION
Issue #25

### 概要
休日スケジュール詳細機能を作成して、スケジュール詳細画面で、複数eventの作成機能と一覧機能を作成する。
タイトル、開始時間、終了時間、金額、画像、コメントを入力してイベントを作成する。

### コメント
Turbo Streamsを活用して、スケジュール詳細画面内で、イベントの新規作成を行えるように実装。